### PR TITLE
docs: apply feedback and prepare v0.9.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,36 @@
 # Changelog
 
 This changelog provides a brief overview of recent updates to the documentation.  
-For detailed changes, please refer to **Section D. Change Notes** within each guide.
+For detailed changes, please refer to **Section Change Notes** within each guide.
 
 ---
+
+## 2025-09-25
+
+Thanks to Reddit feedback and [JamesOBenson](https://github.com/JamesOBenson)
+
+### PBS8
+
+- Moved section 1.2.7 to 1.2.8
+- Moved section 3.3 to 3.4
+- Moved section 3.4 to 3.5
+- Moved change notes out of appendix
+- Added 1.1.7: Enable “non-free-firmware” repositories
+- Added 1.1.8: Install CPU microcode
+- Added 1.2.7: Run container platforms inside VMs
+- Added 2.1.4: Emergency “break-glass” root access policy
+- Added 3.3: Ceph pool sizing and failure domains
+- Added Appendix D
+- Minor wording and formatting improvements
+
+### PBS3
+
+- Moved change notes out of appendix
+- Added 1.1.6: Enable “non-free-firmware” repositories
+- Added 1.1.7: Install CPU microcode
+- Added 2.1.4: Emergency “break-glass” root access policy
+- Added Appendix D
+- Minor wording and formatting improvements
 
 ## 2025-08-31
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for helping improve the **Proxmox Hardening Guides**!
 2. Fork, create a feature branch, then open a PR against **dev**. The main branch remains stable, while contributions are reviewed, tested, and merged in an organized way.
 3. One logical change per PR.
 4. Follow the existing typographical conventions.
-5. If your change is merged, add an entry to the **Change Notes** appendix.
+5. If your change is merged, add an entry to the **Change Notes**.
 
 ### Commit Style
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Some steps are flagged with “Controls have **not** yet been validated.” If y
 - 1.2.1.1 - Enable UEFI Secure Boot
 - 1.2.1.2 - Kernel Lockdown (Integrity Mode)
 - 1.3 - SDN
-- 3.4 - Ceph Messenger Encryption (In-Flight)
+- 3.5 - Ceph Messenger Encryption (In-Flight)
 - 5.3.2 - Rootkit Detection
 
 **PBS 3 guide - items to validate**
@@ -52,8 +52,8 @@ Some steps are flagged with “Controls have **not** yet been validated.” If y
 
 | Guide | Product | Guide Version | Path |
 |-------|---------|---------|------|
-| **PVE 8** | Proxmox Virtual Environment 8.x | 0.9.0 - 31 August 2025 | [`docs/pve8-hardening-guide.md`](docs/pve8-hardening-guide.md) |
-| **PBS 3** | Proxmox Backup Server 3.x | 0.9.0 - 31 August 2025 | [`docs/pbs3-hardening-guide.md`](docs/pbs3-hardening-guide.md) |
+| **PVE 8** | Proxmox Virtual Environment 8.x | 0.9.1 - 25 September 2025 | [`docs/pve8-hardening-guide.md`](docs/pve8-hardening-guide.md) |
+| **PBS 3** | Proxmox Backup Server 3.x | 0.9.1 - 25 September 2025 | [`docs/pbs3-hardening-guide.md`](docs/pbs3-hardening-guide.md) |
 
 **Key Benefits:**
 


### PR DESCRIPTION
This PR applies feedback, and prepares the project for the next release (v0.9.1).

### Summary of changes:

#### PVE8

- Moved section 1.2.7 to 1.2.8
- Moved section 3.3 to 3.4, and 3.4 to 3.5
- Moved change notes out of appendix
- Added:
  - 1.1.7: Enable “non-free-firmware” repositories
  - 1.1.8: Install CPU microcode
  - 1.2.7: Run container platforms inside VMs
  - 2.1.4: Emergency “break-glass” root access policy
  - 3.3: Ceph pool sizing and failure domains
  - Appendix D
- Minor wording and formatting fixes

#### PBS3

- Moved change notes out of appendix
- Added:
  - 1.1.6: Enable “non-free-firmware” repositories
  - 1.1.7: Install CPU microcode
  - 2.1.4: Emergency “break-glass” root access policy
  - Appendix D
- Minor wording and formatting fixes

### Notes

- Changelog entry for added
- README and CONTRIBUTING lightly updated
