### PR TITLE
fix: remove unsafe atime/noatime recommendations for PBS and PVE

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,19 @@ For detailed changes, please refer to **Section Change Notes** within each guide
 
 ---
 
+## 2025-10-05
+
+Thanks to [Onslow](https://forum.proxmox.com/members/onslow.317257/)
+
+### PBS8
+
+- Removed noatime in 1.1.6
+
+### PBS3
+
+- Removed relatime and atime=off in 1.2.4
+- Removed noatime in 1.2.5
+
 ## 2025-09-25
 
 Thanks to Reddit feedback and [JamesOBenson](https://github.com/JamesOBenson)

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Some steps are flagged with “Controls have **not** yet been validated.” If y
 
 | Guide | Product | Guide Version | Path |
 |-------|---------|---------|------|
-| **PVE 8** | Proxmox Virtual Environment 8.x | 0.9.1 - 25 September 2025 | [`docs/pve8-hardening-guide.md`](docs/pve8-hardening-guide.md) |
-| **PBS 3** | Proxmox Backup Server 3.x | 0.9.1 - 25 September 2025 | [`docs/pbs3-hardening-guide.md`](docs/pbs3-hardening-guide.md) |
+| **PVE 8** | Proxmox Virtual Environment 8.x | 0.9.2 - 05 October 2025 | [`docs/pve8-hardening-guide.md`](docs/pve8-hardening-guide.md) |
+| **PBS 3** | Proxmox Backup Server 3.x | 0.9.2 - 05 October 2025 | [`docs/pbs3-hardening-guide.md`](docs/pbs3-hardening-guide.md) |
 
 **Key Benefits:**
 

--- a/docs/pbs3-hardening-guide.md
+++ b/docs/pbs3-hardening-guide.md
@@ -1,6 +1,6 @@
 # Proxmox Backup Server 3.x Hardening Guide
 
-### Version 0.9.1 - September 25, 2025
+### Version 0.9.2 - October 05, 2025
 
 ### Author: [HomeSecExplorer](https://github.com/HomeSecExplorer)
 
@@ -538,13 +538,12 @@ This isolates backup writes from the OS, helps avoid full-disk conditions, and a
 - Create a **separate block device/LV/mount** per datastore (recommended), or a separate ZFS dataset per datastore.
 - Use the following mount options and properties:
    - ext4 / XFS
-      - mount options: `defaults,relatime,nodev,nosuid,noexec`
+      - mount options: `defaults,nodev,nosuid,noexec`
 - **ZFS dataset**
    - properties:
       ```bash
       # example pool/dataset: tank/pbs/ds1
       zfs create -o mountpoint=<</mnt/pbs-ds1>> <<tank/pbs/ds1>>
-      zfs set atime=off            <<tank/pbs/ds1>>
       zfs set compression=zstd-3   <<tank/pbs/ds1>>
       zfs set xattr=sa             <<tank/pbs/ds1>>
       zfs set acltype=posixacl     <<tank/pbs/ds1>>
@@ -580,7 +579,7 @@ Configure authentication and transport encryption, and use mount options that re
 
 - **NFS (preferred over SMB when available)**
    - Use **NFSv4.1/4.2** over TCP with Kerberos privacy:
-      - Client mount options: `rw,vers=4.2,sec=krb5p,hard,noatime,nodev,nosuid,noexec,_netdev,x-systemd.automount,x-systemd.idle-timeout=600`
+      - Client mount options: `rw,vers=4.2,sec=krb5p,hard,nodev,nosuid,noexec,_netdev,x-systemd.automount,x-systemd.idle-timeout=600`
    - **Server-side export** hardening (on the NFS server):
       - Prefer `sync` exports (with SLOG if using ZFS), `root_squash`, `sec=krb5p`, and limit `rw` to PBS IPs.
       - Disable insecure legacy protocols/versions; use `v4 only` where possible.
@@ -1477,3 +1476,4 @@ All CIS control references - section numbers (e.g., **1.1.1**), Level tags (**Le
 |---------|------------|---------------------|------------------------------------------------|-------------|
 | 0.9.0   | 2025-08-31 | HomeSecExplorer     | Initial creation.                              |   --------  |
 | 0.9.1   | 2025-09-25 | HomeSecExplorer     | Expanded guide: move Change Notes; edit 1.1.5 (add ZFS), 1.2.2 (IPMI), rephrase 1.2.3, 4.2.2; added 1.1.6 non-free-firmware, 1.1.7 CPU microcode, 2.1.4 break-glass access with password policy, Appendix D Installation checklists Host; minor edits. |   --------  |
+| 0.9.2   | 2025-10-05 | HomeSecExplorer     | Remove 1.2.4 relatime and ZFS atime=off; 1.2.5 noatime mount options |   --------  |

--- a/docs/pve8-hardening-guide.md
+++ b/docs/pve8-hardening-guide.md
@@ -1,6 +1,6 @@
 # Proxmox VE 8.x Hardening Guide
 
-### Version 0.9.1 - September 25, 2025
+### Version 0.9.2 - October 05, 2025
 
 ### Author: [HomeSecExplorer](https://github.com/HomeSecExplorer)
 
@@ -449,7 +449,7 @@ LUKS2 is used for block-device encryption; keys are required at boot.
 
 **Description**\
 Isolates Proxmox VE local directory storage (`/var/lib/vz`) from the root filesystem to prevent space exhaustion from guest images, ISOs, and templates.
-Enables safe mount options (`defaults,noatime,discard,nodev,nosuid`) without breaking tooling. **Do not** use `noexec` here, guest hooks and maintenance tools may need to run from this path.
+Enables safe mount options (`defaults,discard,nodev,nosuid`) without breaking tooling. **Do not** use `noexec` here, guest hooks and maintenance tools may need to run from this path.
 
 **Measures**
 
@@ -461,7 +461,7 @@ Enables safe mount options (`defaults,noatime,discard,nodev,nosuid`) without bre
   ```
   Add to `/etc/fstab`:
   ```fstab
-  /dev/<<VG>>/vz  /var/lib/vz  xfs  defaults,noatime,discard,nodev,nosuid  0 2
+  /dev/<<VG>>/vz  /var/lib/vz  xfs  defaults,discard,nodev,nosuid  0 2
   ```
   Then mount and verify:
   ```bash
@@ -1869,3 +1869,4 @@ All CIS control references - section numbers (e.g., **1.1.1**), Level tags (**Le
 |---------|------------|---------------------|------------------------------------------------|-------------|
 | 0.9.0   | 2025-08-31 | HomeSecExplorer     | Initial creation.                              |   --------  |
 | 0.9.1   | 2025-09-25 | HomeSecExplorer     | Expanded guide: move Change Notes, 1.2.7 to 1.2.8, 3.3 to 3.4, 3.4 to 3.5; edit 1.1.5 (add ZFS), 1.2.2 (IPMI), rephrase 1.2.3, 1.2.8, 4.2.2/4.4; added 1.1.7 non-free-firmware, 1.1.8 CPU microcode, 2.1.4 break-glass access with password policy, 3.3 Ceph pool sizing and failure domains, Appendix D Installation checklists Host&VMs; minor edits. |   --------  |
+| 0.9.2   | 2025-10-05 | HomeSecExplorer     | Remove 1.1.6 noatime mount option |   --------  |


### PR DESCRIPTION
### Summary

This PR removes incorrect recommendations involving `atime`, `relatime` and `noatime` settings in the PBS and PVE hardening guides.

### 🔧 Context

- **PBS relies on `atime`** (access time) to determine which backup chunks are still referenced.
- Disabling `atime` (via `zfs set atime=off` or `noatime` in ext4 mount options) causes PBS to **delete live backups** during garbage collection.
- Additionally, `noatime` and `relatime` may interfere with guest tools, hooks, or monitoring agents in PVE/PBS.

### ✅ Changes

- PBS3**
  - Removed `zfs set atime=off` recommendation in ZFS dataset examples and `relatime` in PBS3 section 1.2.4
  - Removed `noatime` from ext4 mount option examples in PBS3 section 1.2.5
- **PVE8**
  - Removed `noatime` from mount options in section 1.1.6

### 📚 Reference
- [PBS Garbage Collection documentation](https://pbs.proxmox.com/docs/maintenance.html#gc-background)

### 🙏 Acknowledgements
Thanks to [Onslow](https://forum.proxmox.com/members/onslow.317257/) for catching this critical detail.

---

This change prevents backup loss and ensures compatibility with PBS’s GC process and PVE's guest tooling.